### PR TITLE
add polygon test

### DIFF
--- a/lib/main_polygon.dart
+++ b/lib/main_polygon.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong/latlong.dart';
+import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map_dragmarker/dragmarker.dart';
+import 'polyeditor.dart';
+
+void main() {
+  runApp(TestApp());
+}
+
+class TestApp extends StatefulWidget {
+  @override
+  _TestAppState createState() => _TestAppState();
+}
+
+class _TestAppState extends State<TestApp> {
+  PolyEditor polyEditor;
+
+  List<Polyline> polyLines = [];
+  static const d = 1;
+  var testPolyline = new Polyline(color: Colors.deepOrange, points: [
+    LatLng(45.5231 - d, -122.676 - d),
+    LatLng(45.5231 + d, -122.676 - d),
+    LatLng(45.5231 + d, -122.676 + d),
+    LatLng(45.5231 - d, -122.676 + d),
+    LatLng(45.5231 - d, -122.676 - d),
+  ]);
+
+  @override
+  void initState() {
+    super.initState();
+
+    polyEditor = new PolyEditor(
+      addClosePathMarker: true,
+      points: testPolyline.points,
+      pointIcon: Icon(Icons.crop_square, size: 23),
+      intermediateIcon: Icon(Icons.lens, size: 15, color: Colors.grey),
+      callbackRefresh: () => {this.setState(() {})},
+    );
+
+    polyLines.add(testPolyline);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Container(
+            child: FlutterMap(
+              options: MapOptions(
+                onTap: (ll) {
+                  polyEditor.add(testPolyline.points, ll);
+                },
+                plugins: [
+                  DragMarkerPlugin(),
+                ],
+                center: LatLng(45.5231, -122.6765),
+                zoom: 6.4,
+              ),
+              layers: [
+                // TileLayerOptions(
+                //     urlTemplate:
+                //         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                //     subdomains: ['a', 'b', 'c']),
+                PolylineLayerOptions(polylines: polyLines),
+                DragMarkerPluginOptions(markers: polyEditor.edit()),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
In this PR I just added a main class to test an existing polygon.

The polyline is created a linearring, i.e. first and last coordinate are the same.

```
  static const d = 1;
  var testPolyline = new Polyline(color: Colors.deepOrange, points: [
    LatLng(45.5231 - d, -122.676 - d),
    LatLng(45.5231 + d, -122.676 - d),
    LatLng(45.5231 + d, -122.676 + d),
    LatLng(45.5231 - d, -122.676 + d),
    LatLng(45.5231 - d, -122.676 - d),
  ]);
```

This results in this:
![image](https://user-images.githubusercontent.com/390250/95454594-f535e500-096c-11eb-936f-26041249db5b.png)
if I try to drag the lower left handle:
![image](https://user-images.githubusercontent.com/390250/95454662-0aab0f00-096d-11eb-9f82-f267054e65c3.png)
and if I then drag the remaining:
![image](https://user-images.githubusercontent.com/390250/95454719-1ac2ee80-096d-11eb-9d86-20cfe9102d17.png)

On a second try (pulling the same handle from one more top corner (so not really reproducible), I get this:
![image](https://user-images.githubusercontent.com/390250/95454867-4cd45080-096d-11eb-913e-259cd1049477.png)
the issue here is that there are two handlers even if the node represents a single point of the polygon.

If I try to leave away the closing polygon point using:
```
  var testPolyline = new Polyline(color: Colors.deepOrange, points: [
    LatLng(45.5231 - d, -122.676 - d),
    LatLng(45.5231 + d, -122.676 - d),
    LatLng(45.5231 + d, -122.676 + d),
    LatLng(45.5231 - d, -122.676 + d),
  ]);
```
then I get this:
![image](https://user-images.githubusercontent.com/390250/95455030-8ad17480-096d-11eb-9c56-9ef55dccf04d.png)
which behaves properly:
![image](https://user-images.githubusercontent.com/390250/95455065-958c0980-096d-11eb-9534-cab1f0887ccf.png)
but misses the closing edge.

The polyline is created on a different Polyline object. Wouldn't it be possible to have also the polyline rendered by the polyEditor? 
If there is something I can do to help, just let me know. 


