### PR TITLE
Support v5 versions of `flutter_map` and `flutter_map_dragmarker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,33 @@
-##4.1.0
--  Moving to use dragmarker package
+## 5.0.0
 
-##4.0.3
--  Making compatible with flutter_map ^4.0.0
+- Add support for `flutter_map` v5 and `flutter_map_dragmarker` v5
 
-##4.0.2
--  Tighten latlng2 dep
+## 4.1.0
+
+- Moving to use dragmarker package
+
+## 4.0.3
+
+- Making compatible with `flutter_map` ^4.0.0
+
+## 4.0.2
+
+- Tighten latlng2 dep
 
 ## 4.0.1
--  Including separate dragmarker script, as they are a bit incompatible atm.
+
+- Including separate dragmarker script, as they are a bit incompatible atm.
 
 ## 4.0.0
+
 - `flutter_map` releasing for v3, released v3 line editor in error
 
 ## 3.0.0+beta.1
+
 - `flutter_map` preparing for ^3.0.0-beta.1
 
 ## 3.0.0
+
 - `flutter_map` dependency bumped to ^2.0.0
 
 ## 2.0.0
@@ -26,4 +37,4 @@
 
 ## 1.0.0+
 
-  Start
+Start

--- a/README.md
+++ b/README.md
@@ -1,21 +1,48 @@
-# flutter_map_line_editor
+# Line & Polygon Editor for `flutter_map`
 
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/F1F8E2YBE)
+[![pub package][pub_badge]][pub_link]
+[![License: MIT][license_badge]][license_link]
+[![Support me on Ko-fi][kofi_badge]][kofi_link]
 
-A basic line and polygon editor that works with [`flutter_map`](https://github.com/fleaflet/flutter_map/) relying on `DragMarker` by [`flutter_map_dragmarker`](https://github.com/ibrierley/flutter_map_dragmarker).
+A basic line and polygon editor that works with
+[`flutter_map`](https://github.com/fleaflet/flutter_map/), relying on
+`DragMarker` from
+[`flutter_map_dragmarker`](https://github.com/ibrierley/flutter_map_dragmarker).
 
 ![Demo](https://user-images.githubusercontent.com/3901173/84055684-18e02300-a9ad-11ea-8ee6-cbcfbf361391.gif)
 
 ![Demo](./line_editor_poly.gif)
 
-See the `example` directory for basic usage, here are the most important features:
+## Getting started
+
+To use this package, first add `flutter_map_line_editor` as a
+[dependency in your `pubspec.yaml` file][using-packages-link]:
+
+```yaml
+dependencies:
+  flutter_map_line_editor: <latest version>
+```
+
+See the `example` directory for a complete example app demonstrating the usage
+of this package, here are the most important features:
 
 - Tap the map to add a marker, add as many as you want.
 - Drag the main points to move them.
-- Drag the intermediate points to create a new point there and drag to where you want.
+- Drag the intermediate points to create a new point there and drag to where you
+  want.
 - Long press to delete a point.
 
-Set up a new editor instance with:
+## Usage
+
+Once the package is installed, make sure to import the package in the file that
+you are going to need it, you may also need to import `flutter_map_dragmarker`:
+
+```dart
+import 'package:flutter_map_dragmarker/flutter_map_dragmarker.dart';
+import 'package:flutter_map_line_editor/flutter_map_line_editor.dart';
+```
+
+Set up a new editor instance, tipically inside `initState()`:
 
 ```dart
 var polyEditor = PolyEditor(
@@ -27,12 +54,25 @@ var polyEditor = PolyEditor(
 );
 ```
 
-point is a list of latlong points that are used for the polyline or whatever. It doesn't actually care it's a polyline, it could be something else, but it will put drag points over the top of the latlong points. The list will be edited in place, as it's just a reference as such. So flutter calls build each time, it will use the updated points.
-pointIcon is the icon to use for your main points to drag.
-intermediateIcon is halfway between the main points. If you drag this icon, it will separate the line its on, into 2 new lines and attach draggable icons to it again.
-callbackRefresh, the screen needs to be updated during a drag, so this will get called each drag frame.
+The `PolyEditor` takes a list of `LatLng` points that are used to put
+`DragMarker`'s over these locations. `PolyEditor` does not care if the given
+list of points is a polyline, it could be something else. This list will be
+edited in place so that when the build method is triggered it will use updated
+points.
 
-Added: addClosePathMarker: true/false, if you have a closed path/polygon where the end auto returns to the start, set this to true, otherwise set to false (eg most polylines).
+You must also pass a `Widget` (tipically an `Icon`) using the `pointIcon`
+parameter that will be used to represent each `DragMarker`.
+
+You may also pass the optional parameter `intermediateIcon`to display another
+`DragMarker` halfway between the main points. Dragging this marker will create
+another main point and the line will be split.
+
+The screen needs to be updated during a drag, so `callbackRefresh` takes a
+function that will get called each drag frame.
+
+For polygons or “closed paths” set the parameter `addClosePathMarker` to `true`
+so that the end auto-returns to the start. Otherwise, if you just want a basic
+polyline, set this to false.
 
 You can add a point programmatically using the `onTap` callback in `MapOptions`:
 
@@ -40,7 +80,40 @@ You can add a point programmatically using the `onTap` callback in `MapOptions`:
 onTap: (ll) {
   polyEditor.add(testPolyline.points, ll);
 },
- ```
+```
 
+Add the correspondent layers as `FlutterMap` childrens:
 
-Pull requests welcome!
+```dart
+FlutterMap(
+  options: MapOptions(
+    onTap: (_, ll) {
+      polyEditor.add(testPolyline.points, ll);
+    },
+  ),
+  children: [
+    // .....
+    PolylineLayer(polylines: polyLines),
+    DragMarkers(markers: polyEditor.edit()),
+  ],
+),
+```
+
+> Report issues or feature requests in the [GitHub repository][issue-tracker],
+> Pull Requests are welcome!
+
+## License
+
+This package is licensed under the permissive [MIT License][mit-license-link].
+See the [`LICENSE`][license-link] file in this repository to get a full copy.
+
+[license_badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[license_link]: https://opensource.org/licenses/MIT
+[mit-license-link]: https://mit-license.org/
+[license-link]: https://raw.githubusercontent.com/ibrierley/flutter_map_line_editor/master/LICENSE
+[pub_badge]: https://img.shields.io/pub/v/flutter_map_line_editor.svg
+[pub_link]: https://pub.dartlang.org/packages/flutter_map_line_editor
+[kofi_badge]: https://ko-fi.com/img/githubbutton_sm.svg
+[kofi_link]: https://ko-fi.com/F1F8E2YBE
+[using-packages-link]: https://docs.flutter.dev/packages-and-plugins/using-packages
+[issue-tracker]: https://github.com/ibrierley/flutter_map_line_editor/issues

--- a/example/lib/list_page.dart
+++ b/example/lib/list_page.dart
@@ -53,6 +53,8 @@ class _ListPageState extends State<ListPage> {
                       onTap: (_, ll) {
                         polyEditor.add(testPolyline.points, ll);
                       },
+                      // For backwards compatibility with pre v5 don't use const
+                      // ignore: prefer_const_constructors
                       center: LatLng(45.5231, -122.6765),
                       zoom: 10,
                     ),

--- a/example/lib/polygon_page.dart
+++ b/example/lib/polygon_page.dart
@@ -46,6 +46,8 @@ class _PolygonPageState extends State<PolygonPage> {
           onTap: (_, ll) {
             polyEditor.add(testPolygon.points, ll);
           },
+          // For backwards compatibility with pre v5 don't use const
+          // ignore: prefer_const_constructors
           center: LatLng(45.5231, -122.6765),
           zoom: 10,
         ),

--- a/example/lib/polyline_page.dart
+++ b/example/lib/polyline_page.dart
@@ -43,6 +43,8 @@ class _PolylinePageState extends State<PolylinePage> {
           onTap: (_, ll) {
             polyEditor.add(testPolyline.points, ll);
           },
+          // For backwards compatibility with pre v5 don't use const
+          // ignore: prefer_const_constructors
           center: LatLng(45.5231, -122.6765),
           zoom: 10,
         ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: Example app showcasing usage of flutter_map_line_editor.
 publish_to: 'none'
-version: 4.1.0
+version: 5.0.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^4.0.0
-  flutter_map_dragmarker: ^4.1.3
-  latlong2: ">=0.8.0 <0.9.0"
+  flutter_map: ">=4.0.0 <6.0.0"
+  flutter_map_dragmarker: ">=4.0.0 <6.0.0"
+  latlong2: ">=0.8.0 <0.10.0"
   flutter_map_line_editor:
     path: ../
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  latlong2: ">=0.8.0 <0.9.0"
-  flutter_map_dragmarker: ^4.1.3
+  latlong2: ">=0.8.0 <0.10.0"
+  flutter_map_dragmarker: ">=4.0.0 <6.0.0"
 
 dev_dependencies:
   flutter_lints: ">=1.0.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map_line_editor
-description: Line editor class for flutter_map
-version: 4.1.0
+description: A basic Line and Polygon editor for `flutter_map` using drag markers
+version: 5.0.0
 repository: https://github.com/ibrierley/flutter_map_line_editor
 
 environment:


### PR DESCRIPTION
These latest versions of our dependencies do not introduce breaking changes in this package, regardless, I've updated the major version of this package to v5 as well to be in sync. While I was here, I've also taken the time to improve the readme a bit and update the changelog, so it is ready to be released on pub.dev.