### PR TITLE
Updated flutter_map_dragmarker for flutter_map ^6.0.0-dev.3 support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
   latlong2: ">=0.8.0 <0.10.0"
-  flutter_map_dragmarker: ">=4.0.0 <6.0.0"
+  flutter_map_dragmarker:
+    git: https://github.com/shrijanRegmi/flutter_map_dragmarker.git
 
 dev_dependencies:
   flutter_lints: ">=1.0.4"


### PR DESCRIPTION
I wanted to try out flutter_map v6 in one of my projects, and I didn't want to wait, so I took the initiative to update the flutter_map_dragmarker myself. I already sent a PR to [flutter_map_dragmarker](https://github.com/ibrierley/flutter_map_dragmarker/pull/36). Please take a moment to update the dependency after flutter_map_dragmarker's update.