### PR TITLE
Add current point to callbackRefresh

### DIFF
--- a/example/lib/list_page.dart
+++ b/example/lib/list_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter_map_line_editor/flutter_map_line_editor.dart';
 import 'package:latlong2/latlong.dart';
 
 class ListPage extends StatefulWidget {
-  const ListPage({Key? key}) : super(key: key);
+  const ListPage({super.key});
 
   @override
   State<ListPage> createState() => _ListPageState();
@@ -26,7 +26,7 @@ class _ListPageState extends State<ListPage> {
       points: testPolyline.points,
       pointIcon: const Icon(Icons.crop_square, size: 23),
       intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
-      callbackRefresh: (_) {
+      callbackRefresh: (LatLng? _) {
         //debugPrint("polyedit setstate");
         setState(() {});
       },

--- a/example/lib/list_page.dart
+++ b/example/lib/list_page.dart
@@ -26,7 +26,7 @@ class _ListPageState extends State<ListPage> {
       points: testPolyline.points,
       pointIcon: const Icon(Icons.crop_square, size: 23),
       intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
-      callbackRefresh: () {
+      callbackRefresh: (_) {
         //debugPrint("polyedit setstate");
         setState(() {});
       },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/list_page.dart';
+import 'package:example/map_in_map_page.dart';
 import 'package:example/polygon_page.dart';
 import 'package:example/polyline_page.dart';
 import 'package:flutter/material.dart';
@@ -8,7 +9,7 @@ void main() {
 }
 
 class App extends StatefulWidget {
-  const App({Key? key}) : super(key: key);
+  const App({super.key});
 
   @override
   State<App> createState() => _AppState();
@@ -27,9 +28,12 @@ class _AppState extends State<App> {
             PolylinePage(),
             PolygonPage(),
             ListPage(),
+            MapInMapPage()
           ],
         ),
         bottomNavigationBar: BottomNavigationBar(
+          unselectedItemColor: Colors.black45,
+          selectedItemColor: Colors.black,
           currentIndex: _selectedIndex,
           onTap: (index) => setState(() {
             _selectedIndex = index;
@@ -46,6 +50,10 @@ class _AppState extends State<App> {
             BottomNavigationBarItem(
               icon: Icon(Icons.list),
               label: 'List',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.zoom_in),
+              label: 'Map in Map',
             ),
           ],
         ),

--- a/example/lib/map_in_map_page.dart
+++ b/example/lib/map_in_map_page.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_dragmarker/flutter_map_dragmarker.dart';
+import 'package:flutter_map_line_editor/flutter_map_line_editor.dart';
+import 'package:latlong2/latlong.dart';
+
+class MapInMapPage extends StatefulWidget {
+  const MapInMapPage({super.key});
+
+  @override
+  State<MapInMapPage> createState() => _MapinMapPageState();
+}
+
+class _MapinMapPageState extends State<MapInMapPage> {
+  late PolyEditor polyEditor;
+  final MapController mapController = MapController();
+  final polyLines = <Polyline>[];
+  final testPolyline = Polyline(color: Colors.deepOrange, points: []);
+  LatLng? currentPoint = const LatLng(45.5231, -122.6765);
+
+  @override
+  void initState() {
+    polyEditor = PolyEditor(
+      addClosePathMarker: false,
+      points: testPolyline.points,
+      pointIcon: const Icon(Icons.crop_square, size: 23),
+      intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
+      callbackRefresh: (LatLng? point) {
+        //debugPrint("polyedit setstate");
+        if (point != null) {
+          mapController.move(point, 16);
+        }
+        setState(() {});
+      },
+    );
+    polyLines.add(testPolyline);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Map in Map example')),
+      body: Stack(
+        children: [
+          FlutterMap(
+            options: MapOptions(
+              onTap: (_, ll) {
+                polyEditor.add(testPolyline.points, ll);
+              },
+              // For backwards compatibility with pre v5 don't use const
+              // ignore: prefer_const_constructors
+              initialCenter: LatLng(45.5231, -122.6765),
+              initialZoom: 10,
+            ),
+            children: [
+              TileLayer(
+                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              ),
+              PolylineLayer(polylines: polyLines),
+              DragMarkers(markers: polyEditor.edit()),
+            ],
+          ),
+          SizedBox(
+            width: MediaQuery.of(context).size.width / 5,
+            height: MediaQuery.of(context).size.width / 5,
+            child: FlutterMap(
+              mapController: mapController,
+              options: const MapOptions(
+                interactionOptions:
+                    InteractionOptions(flags: InteractiveFlag.none),
+                // For backwards compatibility with pre v5 don't use const
+                // ignore: prefer_const_constructors
+                initialCenter: LatLng(45.5231, -122.6765),
+                initialZoom: 16,
+              ),
+              children: [
+                TileLayer(
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                ),
+                PolylineLayer(polylines: polyLines),
+                DragMarkers(markers: polyEditor.edit()),
+              ],
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.replay),
+        onPressed: () {
+          setState(() {
+            testPolyline.points.clear();
+          });
+        },
+      ),
+    );
+  }
+}

--- a/example/lib/polygon_page.dart
+++ b/example/lib/polygon_page.dart
@@ -30,7 +30,7 @@ class _PolygonPageState extends State<PolygonPage> {
       points: testPolygon.points,
       pointIcon: const Icon(Icons.crop_square, size: 23),
       intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
-      callbackRefresh: () => {setState(() {})},
+      callbackRefresh: (_) => {setState(() {})},
     );
 
     polygons.add(testPolygon);

--- a/example/lib/polygon_page.dart
+++ b/example/lib/polygon_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter_map_line_editor/flutter_map_line_editor.dart';
 import 'package:latlong2/latlong.dart';
 
 class PolygonPage extends StatefulWidget {
-  const PolygonPage({Key? key}) : super(key: key);
+  const PolygonPage({super.key});
 
   @override
   State<PolygonPage> createState() => _PolygonPageState();
@@ -30,7 +30,7 @@ class _PolygonPageState extends State<PolygonPage> {
       points: testPolygon.points,
       pointIcon: const Icon(Icons.crop_square, size: 23),
       intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
-      callbackRefresh: (_) => {setState(() {})},
+      callbackRefresh: (LatLng? _) => {setState(() {})},
     );
 
     polygons.add(testPolygon);

--- a/example/lib/polyline_page.dart
+++ b/example/lib/polyline_page.dart
@@ -24,7 +24,7 @@ class _PolylinePageState extends State<PolylinePage> {
       points: testPolyline.points,
       pointIcon: const Icon(Icons.crop_square, size: 23),
       intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
-      callbackRefresh: () {
+      callbackRefresh: (_) {
         //debugPrint("polyedit setstate");
         setState(() {});
       },

--- a/example/lib/polyline_page.dart
+++ b/example/lib/polyline_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter_map_line_editor/flutter_map_line_editor.dart';
 import 'package:latlong2/latlong.dart';
 
 class PolylinePage extends StatefulWidget {
-  const PolylinePage({Key? key}) : super(key: key);
+  const PolylinePage({super.key});
 
   @override
   State<PolylinePage> createState() => _PolylinePageState();
@@ -24,7 +24,7 @@ class _PolylinePageState extends State<PolylinePage> {
       points: testPolyline.points,
       pointIcon: const Icon(Icons.crop_square, size: 23),
       intermediateIcon: const Icon(Icons.lens, size: 15, color: Colors.grey),
-      callbackRefresh: (_) {
+      callbackRefresh: (LatLng? _) {
         //debugPrint("polyedit setstate");
         setState(() {});
       },

--- a/lib/src/poly_editor.dart
+++ b/lib/src/poly_editor.dart
@@ -30,7 +30,7 @@ class PolyEditor {
     callbackRefresh?.call(LatLng(point.latitude, point.longitude));
   }
 
-  List add(List<LatLng> pointsList, point) {
+  List add(List<LatLng> pointsList, LatLng point) {
     pointsList.add(point);
     callbackRefresh?.call(point);
     return pointsList;
@@ -38,7 +38,7 @@ class PolyEditor {
 
   LatLng remove(int index) {
     final point = points.removeAt(index);
-    callbackRefresh?.call(null);
+    callbackRefresh?.call(point);
     return point;
   }
 

--- a/lib/src/poly_editor.dart
+++ b/lib/src/poly_editor.dart
@@ -8,7 +8,7 @@ class PolyEditor {
   final Size pointIconSize;
   final Widget? intermediateIcon;
   final Size intermediateIconSize;
-  final Function? callbackRefresh;
+  final void Function(LatLng? updatePoint)? callbackRefresh;
   final bool addClosePathMarker;
 
   PolyEditor({
@@ -27,18 +27,18 @@ class PolyEditor {
     if (_markerToUpdate != null) {
       points[_markerToUpdate!] = LatLng(point.latitude, point.longitude);
     }
-    callbackRefresh?.call();
+    callbackRefresh?.call(LatLng(point.latitude, point.longitude));
   }
 
   List add(List<LatLng> pointsList, point) {
     pointsList.add(point);
-    callbackRefresh?.call();
+    callbackRefresh?.call(point);
     return pointsList;
   }
 
   LatLng remove(int index) {
     final point = points.removeAt(index);
-    callbackRefresh?.call();
+    callbackRefresh?.call(null);
     return point;
   }
 


### PR DESCRIPTION
Hi @ibrierley ,

would it be possible to add the currently manipulated/edited point to the `callbackRefresh` Function? There are not a lot changes needed for that, but I stumble across the need for that functionality in a recent Project (see the video attached). 

I made all the necessary changes in this PR and if you agree with the functionality I can also add a complete example. 

I am also interested if you have an better idea to achieve this :)


Here the example, why I needed this functionality. The small PiP Map uses the point from the callbackRefresh function to serve as a kind of Map Lens.
https://github.com/ibrierley/flutter_map_line_editor/assets/31648877/e0b30db3-9f37-4b91-b444-e44dd0f74055

